### PR TITLE
:arrow_up: Bump excelsior-jet-maven-plugin from 1.3.2 to 1.3.3

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -102,7 +102,7 @@
       <plugin>
         <groupId>com.excelsiorjet</groupId>
         <artifactId>excelsior-jet-maven-plugin</artifactId>
-        <version>1.3.2</version>
+        <version>1.3.3</version>
         <configuration>
           <mainClass>${mainClass}</mainClass>
           <globalOptimizer>true</globalOptimizer>


### PR DESCRIPTION
Bumps excelsior-jet-maven-plugin from 1.3.2 to 1.3.3.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>